### PR TITLE
Exhibit *rejig* support for members

### DIFF
--- a/Exhibit/custom.py
+++ b/Exhibit/custom.py
@@ -1,0 +1,318 @@
+# Members seasoning for status monitoring with standard exhibit node.
+
+from nodetoolkit import *
+
+# <!--- members and status support  
+
+membersBySignal = {}
+    
+def initSignalSupport(name, mode, signalName, states, disappears = False, isGroup = False):
+  members = getMembersInfoOrRegister(signalName, name)
+  
+  # establish local signals if haven't done so already
+  localDesiredSignal = lookup_local_event('Desired %s' % signalName)
+  
+  if localDesiredSignal == None:
+    localDesiredSignal, localResultantSignal = initSignal(signalName, mode, states)
+  else:
+    localResultantSignal = lookup_local_event(signalName)
+      
+  # establish a remote signal to receive status
+  # signal status states include 'Partially ...' forms
+  resultantStates = states + ['Partially %s' % s for s in states]
+  
+  localMemberSignal = Event('Member %s %s' % (name, signalName), {'title': '"%s" %s' % (name, signalName), 'group': 'Members\' %s' % signalName, 'order': 9999+next_seq(), 'schema': {'type': 'string', 'enum': resultantStates}})
+  
+  def aggregateMemberSignals():
+    shouldBeState = localDesiredSignal.getArg()
+    partially = False
+    
+    for memberName in members:
+      if lookup_local_event('Member %s %s' % (memberName, signalName)).getArg() != shouldBeState:
+        partially = True
+        
+    localResultantSignal.emit('Partially %s' % shouldBeState if partially else shouldBeState)
+    
+  localMemberSignal.addEmitHandler(lambda arg: aggregateMemberSignals())
+  localDesiredSignal.addEmitHandler(lambda arg: aggregateMemberSignals())
+  
+  def handleRemoteEvent(arg):
+    if arg == True or arg == 1:
+      arg = 'On'
+    elif arg == False or arg == 0:
+      arg = 'Off'
+    
+    localMemberSignal.emit(arg)
+  
+  create_remote_event('Member %s %s' % (name, signalName), handleRemoteEvent, {'title': '"%s" %s' % (name, signalName),'group': 'Members ("%s")' % signalName, 'order': next_seq(), 'schema': {'type': 'string', 'enum': resultantStates}},
+                      suggestedNode=name, suggestedEvent=signalName)
+                           
+  if disappears:
+    prepareForDisappearingMemberSignal(name, signalName)
+
+def initSignal(signalName, mode, states):
+  resultantStates = states + ['Partially %s' % s for s in states]
+  
+  localDesiredSignal = Event('Desired %s' % signalName, {'group': '%s' % signalName, 'order': next_seq(), 'schema': {'type': 'string', 'enum': states}})
+  
+  localResultantSignal = Event('%s' % signalName, {'group': '%s' % signalName, 'order': next_seq(), 'schema': {'type': 'string', 'enum': resultantStates}})
+                    
+  return localDesiredSignal, localResultantSignal
+
+def getMembersInfoOrRegister(signalName, memberName):
+  members = membersBySignal.get(signalName)
+  if members == None:
+    members = list()
+    membersBySignal[signalName] = members
+    
+  members.append(memberName)
+
+  return members
+
+STATUS_SCHEMA = { 'type': 'object', 'properties': {
+                    'level': { 'type': 'integer', 'order': 1 },
+                    'message': {'type': 'string', 'order': 2 }
+                } }
+
+EMPTY_SET = {}
+  
+def initStatusSupport(name, disappears = False):
+  # look up the members structure (assume
+  members = getMembersInfoOrRegister('Status', name)
+  
+  # check if this node has a status yet
+  selfStatusSignal = lookup_local_event('Status')
+  if selfStatusSignal == None:
+    selfStatusSignal = Event('Status', {'group': 'Status', 'order': next_seq(), 'schema': STATUS_SCHEMA})
+    
+  # status for the member
+  memberStatusSignal = Event('Member %s Status' % name, {'title': '"%s" Status' % name, 'group': 'Members\' Status', 'order': 9999+next_seq(), 'schema': STATUS_SCHEMA})
+  
+  # suppression flag?
+  memberStatusSuppressedSignal = Event('Member %s Status Suppressed' % name, {'title': 'Suppress "%s" Status' % name, 'group': 'Status Suppression', 'order': 9999+next_seq(), 'schema': {'type': 'boolean'}})
+  
+  Action('Member %s Status Suppressed' % name, lambda arg: memberStatusSuppressedSignal.emit(arg), {'title': 'Suppress "%s" Status' % name, 'group': 'Status Suppression', 'order': 9999+next_seq(), 'schema': {'type': 'boolean'}})
+  
+  def aggregateMemberStatus():
+    aggregateLevel = 0
+    aggregateMessage = 'OK'
+    
+    # for composing the aggegate message at the end
+    msgs = []
+    
+    activeSuppression = False
+    
+    for memberName in members:
+      suppressed = lookup_local_event('Member %s Status Suppressed' % memberName).getArg()
+      
+      memberStatus = lookup_local_event('Member %s Status' % memberName).getArg() or EMPTY_SET
+      
+      memberLevel = memberStatus.get('level')
+      if memberLevel == None: # as opposed to the value '0'
+        if suppressed:
+          activeSuppression = True
+          continue
+          
+        memberLevel = 99
+
+      if memberLevel > aggregateLevel:
+        # raise the level (if not suppressed)
+        if suppressed:
+          activeSuppression = True
+          continue
+        
+        aggregateLevel = memberLevel
+      
+      memberMessage = memberStatus.get('message') or 'Has never been seen'
+      if memberLevel > 0:
+        if isBlank(memberMessage):
+          msgs.append(memberName)
+        else:
+          msgs.append('%s: [%s]' % (memberName, memberMessage))
+          
+    if len(msgs) > 0:
+      aggregateMessage = ', '.join(msgs)
+      
+    if activeSuppression:
+      aggregateMessage = '%s (*)' % aggregateMessage
+      
+    selfStatusSignal.emit({'level': aggregateLevel, 'message': aggregateMessage})
+      
+  memberStatusSignal.addEmitHandler(lambda arg: aggregateMemberStatus())
+  memberStatusSuppressedSignal.addEmitHandler(lambda arg: aggregateMemberStatus())
+  
+  def handleRemoteEvent(arg):
+    memberStatusSignal.emit(arg)
+  
+  create_remote_event('Member %s Status' % name, handleRemoteEvent, {'title': '"%s" Status' % name, 'group': 'Members (Status)', 'order': next_seq(), 'schema': STATUS_SCHEMA},
+                       suggestedNode=name, suggestedEvent="Status")
+                           
+  if disappears:
+    prepareForDisappearingMemberStatus(name)
+  
+# members and status support ---!>
+
+# <!--- disappearing members
+
+# (for disappearing signals)
+from org.nodel.core import BindingState
+
+def prepareForDisappearingMemberStatus(name):
+  # lookup it's desired 'Power' signal
+  desiredPowerSignal = lookup_local_event('DesiredPower')
+  
+  # create assumed status
+  assumedStatus = Event('Member %s Assumed Status' % name, { 'group': '(advanced)', 'order': next_seq(), 'schema': {'type': 'object', 'properties': {
+                          'level': {'type': 'integer', 'order': 1},
+                          'message': {'type': 'string', 'order': 2}}}})
+  
+  # create volatile remote binding that just passes through the status anyway
+  disappearingRemoteStatus = create_remote_event('%s Disappearing Status' % name, lambda arg: assumedStatus.emit(arg))
+  
+  # and when there's a wiring fault
+  def checkBindingState():
+    desiredPower = desiredPowerSignal.getArg()
+    
+    wiringStatus = disappearingRemoteStatus.getStatus()
+    
+    if desiredPower == 'On':
+      if wiringStatus != BindingState.Wired:
+        assumedStatus.emit({'level': 2, 'message': 'Power is supposed to be On - no confirmation of that.'})
+        
+      else:
+        # wiringStatus is 'Wired', normal status can be passed through
+        remoteStatusArg = disappearingRemoteStatus.getArg()
+        if remoteStatusArg != None:
+          assumedStatus.emit(remoteStatusArg)
+      
+    
+    elif desiredPower == 'Off':
+      if wiringStatus == BindingState.Wired:
+        assumedStatus.emit({'level': 1, 'message': 'Power should be Off but appears to be alive'})
+        
+      else:
+        # wiringStatus is not 'Wired'
+        assumedStatus.emit({'level': 0, 'message': 'OK'})
+        
+  # check when the status binding state changes
+  disappearingRemoteStatus.addBindingStateHandler(lambda arg: checkBindingState())
+  
+  # and when the power state changes
+  desiredPowerSignal.addEmitHandler(lambda arg: checkBindingState())
+  
+  
+def prepareForDisappearingMemberSignal(name, signalName):
+  # lookup it's desired 'Power' signal
+  desiredPowerSignal = lookup_local_event('DesiredPower')
+  
+  # create assumed signal
+  assumedSignal = Event('Member %s Assumed %s' % (name, signalName), { 'group': '(advanced)', 'order': next_seq(), 'schema': {'type': 'string'}})
+  
+  # create volatile remote binding that just passes through the status anyway
+  disappearingRemoteSignal = create_remote_event('%s Disappearing %s' % (name, signalName), lambda arg: assumedSignal.emit(arg))
+  
+  # and when there's a wiring fault
+  def checkBindingState():
+    desiredPower = desiredPowerSignal.getArg()
+    
+    wiringStatus = disappearingRemoteSignal.getStatus()
+    
+    if wiringStatus == BindingState.Wired:
+      # pass on the remote signal
+      remoteSignalArg = disappearingRemoteSignal.getArg()
+      if remoteSignalArg != None:
+        assumedSignal.emit(remoteSignalArg)
+        
+    else:
+      # wiring status is NOT wired
+      if desiredPower == 'On':
+        assumedSignal.emit('Partially On')
+        
+      elif desiredPower == 'Off':
+        assumedSignal.emit('Off')
+
+  # check when the status binding state changes
+  disappearingRemoteSignal.addBindingStateHandler(lambda arg: checkBindingState())        
+        
+  # and when the power state changes
+  desiredPowerSignal.addEmitHandler(lambda arg: checkBindingState())
+
+# disappearing members ---!>
+
+# <!--- convenience functions
+
+def mustNotBeBlank(name, s):
+  if isBlank(s):
+    raise Exception('%s cannot be blank')
+
+  return s
+
+def isBlank(s):
+  if s == None or len(s) == 0 or len(s.strip()) == 0:
+    return True
+  
+def isEmpty(o):
+  if o == None or len(o) == 0:
+    return True
+
+# convenience functions ---!>
+
+# <!--- attach power
+@after_main
+def attachActionSignals():
+
+  def handlePower(arg):
+    event = lookup_local_event('Desired Power')
+    if event:
+      event.emit(arg)
+
+  action = lookup_local_action('Power')
+  if action:
+    action.addCallHandler(handlePower)
+
+# attach power ---!>
+
+# <!--- default power and muting actions
+powerObj = Power()
+def local_action_Power(arg = None):
+  """{'title':'Power','schema':{'type':'string','enum':['On','Off']},'group':'Power'}"""
+  if arg == 'On':
+    powerObj.enable()
+  elif arg == 'Off':
+    powerObj.disable()
+
+mutingObj = Mute()
+def local_action_Muting(arg = None):
+  """{'title':'Muting','schema':{'type':'string','enum':['On','Off']},'group':'Muting'}"""
+  if arg == 'On':
+    mutingObj.muteOn()
+  elif arg == 'Off':
+    mutingObj.muteOff()
+
+# default power and muting actions ---!>
+
+# <!--- composite signals from script.py
+@after_main
+def extend_node():
+
+  def is_disappearing(device):
+    disappearing_devices = ['PC', 'Computer']
+    if any(name in device for name in disappearing_devices):
+      return True
+
+  # A list of devices requiring power monitoring
+  try:
+    for powered_device in monitor_our_power:
+      initSignalSupport(powered_device, 'Signal Only', 'Power', ['On', 'Off'], disappears = is_disappearing(powered_device))
+  except NameError:
+    console.log("No power monitoring")
+
+  # A list of devices requiring status monitoring
+  try:
+    for device in monitor_our_status:
+
+      initStatusSupport(device, disappears = is_disappearing(device))
+  except NameError:
+    console.log("No status monitoring")
+
+# composite signals from script.py ---!>

--- a/Exhibit/readme.md
+++ b/Exhibit/readme.md
@@ -1,0 +1,94 @@
+# Exhibit Node
+
+An extensible node, designed to bind together multiple device nodes in a common-sense fashion, while including the signal aggregation of the group node.
+
+If your use case doesn't require custom scriptings, including timings, or responding to remote events, then the **group node** is recommended as an alternative.
+
+## Overview
+
+The `custom.py` file will be injected at load, and generate identical actions/events to the group node.
+
+##### Actions
+- Muting
+- Power
+- Status Suppression
+- Power
+
+##### Signals
+- Status
+- Members' Power
+- Members' Status
+- Status Suppression
+
+The `script.py` is formatted to encourage user customisation through basic scripting. 
+
+![scripting_example](https://user-images.githubusercontent.com/9277107/53773179-631e5d00-3f3d-11e9-9865-8f03fb32a81e.gif)
+
+## `script.py` Explanation
+
+###  Libraries required by this Node
+Any supplementary libraries go here.
+</br> *e.g.* `from time import sleep`.
+
+###  Parameters used by this Node
+Any extraneous variables not captured by events, or for supplementary parameters.
+</br>*formatting:* `param_name = Parameter({schema})`
+
+###  Functions used by this Node
+Additional functions written by the user to be utilised alongside the Nodel toolkit functions.
+
+### Local actions this Node provides
+Two classes *(Power and Mute)* containing default functions tied to the local *Power* and *Muting* actions respectively.
+
+``` python
+class Power:
+  """Control enable and disable actions"""
+
+  # called on a Power{'On'}
+  def enable(arg = None):
+    print 'Action Enable requested.'
+    remote_action_PowerOnRP.call()
+
+  # called on a Power{'Off'}  
+  def disable(arg = None):
+    print 'Action Disable requested.'
+    remote_action_PowerOffRP.call()
+```
+
+![poweron_actionenable](https://user-images.githubusercontent.com/9277107/53775203-a67cc980-3f45-11e9-8e2f-1fca8845293a.gif)
+
+### Remote actions this Node provides
+Declarations of all the *remote actions* to be used by this Node.
+
+The format is `remote_action_Name = RemoteAction()`
+
+```python 
+### Example remote actions
+remote_action_MuteOffSD = RemoteAction()
+remote_action_MuteOnSD = RemoteAction()
+```
+
+The remote actions declared here will appear as bindings in the **Advanced mode** section of the node. Then the user can specify which local action, from which node, should be triggered when this remote action is called.
+
+![binding_example](https://user-images.githubusercontent.com/9277107/53775385-7550c900-3f46-11e9-88fb-07f71988982a.jpg)
+
+### Remote events this Node requires
+Declarations of all the *remote events* to be used by this Node.
+
+The format is:
+
+```python
+def remote_event_Example(arg = None):
+  """{"title":"Example","desc":"Example"}"""
+  print 'Remote event Example arrived.'
+  remote_action_PlayClip01.call()
+```
+
+As above, the remote events will generate bindings for the user to declare a relationship with another node.
+
+### Related nodes to aggregate and monitor
+There are two lists `monitor_our_status` and `monitor_our_power` which are to be populated with the names of nodes (or a meaningful alias) meant to be monitored.
+
+This replaces the *members* facility of the group node.
+
+The items listed here will generate bindings as when directly declaring *remote events* or *remote actions*, allowing the user to specify the nodes which require status aggregation.

--- a/Exhibit/script.py
+++ b/Exhibit/script.py
@@ -1,0 +1,86 @@
+'''Exhibit Node'''
+
+
+### Libraries required by this Node
+from time import time
+from random import randint
+
+
+### Parameters used by this Node
+timeout = 0
+param_duration = Parameter('{"title":"Duration (seconds)","schema":{"type":"integer"}}')
+
+
+### Functions used by this Node
+def play_random_clip():
+  x = randint(0,1)
+  if x is 1:
+    local_action_PlayClip01()
+  else:
+    local_action_PlayClip02()
+
+
+### Local actions this Node provides
+class Power:
+  """Control enable and disable actions"""
+
+  def enable(arg = None):
+    print 'Action Enable requested.'
+    remote_action_PowerOnRP.call()
+
+  def disable(arg = None):
+    print 'Action Disable requested.'
+    remote_action_PowerOffRP.call()
+
+class Mute:
+  """Control muting actions"""
+
+  def muteOn(arg = None):
+    print 'Action MuteOn requested.'
+    remote_action_MuteOnSD.call()
+
+  def muteOff(arg = None):
+    print 'Action MuteOff requested.'
+    remote_action_MuteOffSD.call()
+  
+def local_action_PlayClip01(arg = None):
+  """{"title":"PlayClip01","desc":"PlayClip01","group":"Content"}"""
+  print 'Action PlayClip01 requested.'
+  remote_action_PlayClip01.call()
+  
+def local_action_PlayClip02(arg = None):
+  """{"title":"PlayClip02","desc":"PlayClip02","group":"Content"}"""
+  print 'Action PlayClip02 requested.'
+  remote_action_PlayClip02.call()
+
+
+### Remote actions this Node requires
+remote_action_MuteOffSD = RemoteAction()
+remote_action_MuteOnSD = RemoteAction()
+
+remote_action_PlayClip01 = RemoteAction()
+remote_action_PlayClip02 = RemoteAction()
+
+remote_action_PowerOnRP = RemoteAction()
+remote_action_PowerOffRP = RemoteAction()
+
+
+### Remote events this Node requires
+def remote_event_Triggered(arg = None):
+  """{"title":"Triggered","desc":"Triggered"}"""
+  print 'Remote event Triggered arrived.'
+  global timeout
+  if timeout < time():
+    timeout = time() + param_duration
+    play_random_clip()
+
+
+### Related nodes to aggregate and monitor
+monitor_our_status = ['MM-FGRP01','MM-FGIO01']
+monitor_our_power = ['MM-FGRP01']
+
+
+### Main
+def main(arg = None):
+  # Start your script here.
+  print 'Nodel script started.'


### PR DESCRIPTION
It's been \*quite* a point of contention since the introduction of the *group* node in support of the calendar and frontend, which saw the exhibit node fade into history.

There's been several attempts (offline) to marry the friendly extensibility of the exhibit node with the utility of calendar and frontend support. This is my favourite so far. It's used in a couple of exhibitions around Museums Victoria, and there haven't been any issues to my knowledge.

It moves @justparking's "ingredients" script to the auto-loaded `custom.py` and maintains the traditional nomenclature:

```
### Local actions this Node provides
### Remote actions this Node requires
### Remote events this Node requires
### etc...
```

It wraps the power and muting functions seen in the group nodes into classes, for emphasis more than technical requirements. There are also the inclusion of two lists, `monitor_our_status` and `monitor_our_status` which generate members in place of the parameters used in the group node.

There's also a README included this time. :wink: