### PR TITLE
Computer Controller *update*: add audio metering

### DIFF
--- a/Computer Controller/Windows 10/ComputerController.cs
+++ b/Computer Controller/Windows 10/ComputerController.cs
@@ -261,7 +261,7 @@ class ComputerController
         while (s_running)
         {
             Console.WriteLine("{{ event: Meter, arg: {0:0.00} }}", Audio.Meter);
-            await Task.Delay(750); // check every 1.25 seconds
+            await Task.Delay(750); // check every 0.75 seconds
         }
     }
 

--- a/Computer Controller/Windows 10/readme.md
+++ b/Computer Controller/Windows 10/readme.md
@@ -10,15 +10,33 @@ It utilises a work-around used in the **Application** node to build and manage a
 - reboot, shutdown, suspend
 - periodic screenshots
 - basic volume control of primary audio device
-- audio signal metering
+- audio signal metering (dbFS and scalar)
 - CPU monitoring
+
+#### Components
 
 The node utilises Python's `subprocess` module for the **management of system power-states**.
 
 It also includes Java's `File` module for **monitoring system disk-space**.
 
-Finally, the Windows specific special sauce 🍲 is `ComputerController.cs` a built-on-use .NET application for **volume control**, **audio signal metering**, **CPU monitoring** and **screenshotting*.
+Finally, the Windows specific special sauce 🍲 is `ComputerController.cs` a built-on-use .NET application for:
+
+- **volume control**
+- **audio signal metering**
+- **CPU monitoring**
+- **screenshotting**
 
 ## Requirements
 
+#### Process Sandbox
+
+It's **highly recommended** to use the `ProcessSandbox.exe`. It's available on the [release page](https://github.com/museumsvictoria/nodel/releases). This will ensure the .NET isn't left hanging as a result of the nodehost's closure.
+
+The ProcessToolkit responsible for managing the .NET component will automatically search the node's directory and the nodehost root directory for the executable.
+
+#### Testing
+
 This recipe has been tested on *Windows 10* with *.NET Framework 4.0* (which is explicitly referenced as part of the build) but might work with a wider variety of versions.
+
+It has also been tested with Nodel's `r389`, but should support any version where the ProcessToolkit is available.
+

--- a/Computer Controller/Windows 10/readme.md
+++ b/Computer Controller/Windows 10/readme.md
@@ -15,7 +15,7 @@ It utilises a work-around used in the **Application** node to build and manage a
 
 #### Components
 
-The node utilises Python's `subprocess` module for the **management of system power-states**.
+The node utilises `Process` from Nodel Toolkit for the **management of system power-states**.
 
 It also includes Java's `File` module for **monitoring system disk-space**.
 

--- a/Computer Controller/Windows 10/readme.md
+++ b/Computer Controller/Windows 10/readme.md
@@ -10,13 +10,14 @@ It utilises a work-around used in the **Application** node to build and manage a
 - reboot, shutdown, suspend
 - periodic screenshots
 - basic volume control of primary audio device
+- audio signal metering
 - CPU monitoring
 
 The node utilises Python's `subprocess` module for the **management of system power-states**.
 
 It also includes Java's `File` module for **monitoring system disk-space**.
 
-Finally, the Windows specific special sauce 🍲 is `ComputerController.cs` a built-on-use .NET application for **volume control** and **CPU monitoring** and **screenshotting*.
+Finally, the Windows specific special sauce 🍲 is `ComputerController.cs` a built-on-use .NET application for **volume control**, **audio signal metering**, **CPU monitoring** and **screenshotting*.
 
 ## Requirements
 

--- a/Computer Controller/Windows 10/readme.md
+++ b/Computer Controller/Windows 10/readme.md
@@ -32,7 +32,7 @@ Finally, the Windows specific special sauce 🍲 is `ComputerController.cs` a bu
 
 It's **highly recommended** to use the `ProcessSandbox.exe`. It's available on the [release page](https://github.com/museumsvictoria/nodel/releases). This will ensure the .NET isn't left hanging as a result of the nodehost's closure.
 
-The ProcessToolkit responsible for managing the .NET component will automatically search the node's directory and the nodehost root directory for the executable.
+The ProcessToolkit responsible for managing the .NET component will automatically search 🔍 the node's directory and the nodehost root directory for the executable.
 
 #### Testing
 

--- a/Computer Controller/Windows 10/script.py
+++ b/Computer Controller/Windows 10/script.py
@@ -16,7 +16,7 @@ param_FreeSpaceThreshold = Parameter({ 'title': 'Freespace threshold (GB)', 'sch
 
 # <!-- CPU
 
-local_event_CPU = LocalEvent({ 'order': next_seq(), 'schema': { 'type': 'number' }}) # using no group so shows prominentl
+local_event_CPU = LocalEvent({ 'order': next_seq(), 'schema': { 'type': 'number' }}) # using no group so shows prominently
 
 
 # <!--- power
@@ -170,6 +170,7 @@ def controller_feedback(data):
 def controller_started():
   _controller.send('get-mute')
   _controller.send('get-volume')
+  _controller.send('get-volumescalar')
 
 _controller = Process([ '%s\\ComputerController.exe' % _node.getRoot().getAbsolutePath() ], 
                      stdout=controller_feedback, 

--- a/Computer Controller/Windows 10/script.py
+++ b/Computer Controller/Windows 10/script.py
@@ -5,7 +5,8 @@ Includes:
 
 * reboot, shutdown
 * periodic screenshots
-* basic volume control of primary audio device
+* basic volume control and of primary audio device
+* audio signal metering
 * CPU monitoring
 
 '''
@@ -75,11 +76,12 @@ def Volume(arg):
 
     _controller.send('set-volume %s' % arg)
 
+local_event_Meter = LocalEvent({ 'group': 'Volume', 'schema': {'type': 'integer' }})
+
 # mute and volume --!>
 
 
 # <!- status
-
 
 local_event_Status = LocalEvent({ 'group': 'Status', 'order': next_seq(), 'schema': { 'type': 'object', 'properties': {
                                       'level':   {'type': 'integer', 'order': 1 },

--- a/Computer Controller/Windows 10/script.py
+++ b/Computer Controller/Windows 10/script.py
@@ -1,7 +1,5 @@
 '''
-An agent with native Windows operations, tested with Windows 10 but might work on older or newer versions.
-
-Includes:
+An agent with native Windows operations, tested with Windows 10 but might work on older or newer versions. Includes:
 
 * reboot, shutdown
 * periodic screenshots
@@ -39,7 +37,7 @@ def Restart():
 # --->
 
 
-# <!--- mute and volume
+# <!--- mute, volume and meter
 
 local_event_Mute = LocalEvent({ 'group': 'Volume', 'order': next_seq(), 'schema': { 'type': 'boolean' }})
 
@@ -56,19 +54,19 @@ def Mute(arg):
         console.warn('Mute: arg missing')
         return
     
-    _controller.send('set-mute %s' % (1 if state else 0))
+    _controller.send('set-mute %s' % ('true' if state else 'false'))
 
-@local_action({ 'group': 'Mute', 'order': next_seq() })
+@local_action({ 'title': 'On', 'group': 'Mute', 'order': next_seq() })
 def MuteOn():
     Mute.call(True)
 
-@local_action({ 'group': 'Mute', 'order': next_seq() })
+@local_action({ 'title': 'Off', 'group': 'Mute', 'order': next_seq() })
 def MuteOff():
     Mute.call(False)
-
+    
 local_event_Volume = LocalEvent({ 'title': 'Volume (dB)', 'group': 'Volume', 'order': next_seq(), 'schema': {'type': 'number' }})
 
-@local_action({ 'title': 'Volume (dB)', 'group':'Volume', 'order': next_seq(), 'schema': { 'type': 'number', 'hint': '(-infinity to 0 dB or more depending on hardware)' }})
+@local_action({ 'title': 'Volume (dB)', 'group':'Volume', 'order': next_seq(), 'schema': { 'type': 'number', 'hint': '(-infinity to 0.0 dB or more, hardware dependent, see Range)' }})
 def Volume(arg):
     console.info('Volume %s action' % arg)
     
@@ -78,19 +76,24 @@ def Volume(arg):
 
     _controller.send('set-volume %s' % arg)
 
-local_event_VolumeScalar = LocalEvent({ 'title': 'Volume (scalar/linear/percentage)', 'group': 'Volume', 'order': next_seq(), 'schema': {'type': 'number' }})
+local_event_VolumeScalar = LocalEvent({ 'title': 'Volume Scalar (%, tapered)', 'group': 'Volume', 'order': next_seq(), 'schema': {'type': 'number' }})
     
-@local_action({ 'title': 'Volume (scalar/linear/percentage)', 'group':'Volume', 'order': next_seq(), 'schema': { 'type': 'number', 'hint': '(0 - 100)' }})
+@local_action({ 'title': 'Volume Scalar (%, tapered)', 'group':'Volume', 'order': next_seq(), 'schema': { 'type': 'number', 'hint': '(0.0 - 100%, hardware dependent)' }})
 def VolumeScalar(arg):
     if arg == None or arg < 0 or arg > 100:
       console.warn('VolumeScalar: no arg or outside 0 - 100')
       return
     
     _controller.send('set-volumescalar %s' % arg)
+    
+local_event_VolumeRange = LocalEvent({ 'title': 'Range (all in dB)', 'group': 'Volume', 'order': next_seq(), 'schema': {'type': 'object', 'properties': {
+                                           'min': { 'type': 'number', 'order': 1 },
+                                           'max': { 'type': 'number', 'order': 2 },
+                                           'step': { 'type': 'number', 'order': 3 }}}})
 
-local_event_Meter = LocalEvent({ 'title': 'Meter (Peak in dB)', 'group': 'Volume', 'order': next_seq(), 'schema': { 'type': 'number' }})
+local_event_AudioMeter = LocalEvent({ 'title': 'Audio Meter (Peak in dB, hardware dependent)', 'desc': 'NOTE: this meter is very hardware dependent sometimes acting as a pre- gain/mute meter, sometimes post-.', 'order': next_seq(), 'schema': { 'type': 'number' }}) # using no group so shows prominently
 
-# mute and volume --!>
+# mute, volume and meter --!>
 
 
 # <!- status


### PR DESCRIPTION
> Inspired by the recent update (d559cdb5ae3da0534f54fa42016ccdd069e24a96) which introduced support for screenshotting and CPU monitoring by @justparking.

An initial attempt at monitoring peak values in the audio stream using an additional Core Audio interface, [IAudioMeterInformation](https://docs.microsoft.com/en-us/windows/win32/api/endpointvolume/nn-endpointvolume-iaudiometerinformation).

###### I think I'm getting the hang of this now! 😁

<img src="https://user-images.githubusercontent.com/9277107/75452507-ba011b80-5972-11ea-920a-62c6da76baa8.gif" height="250">

It was also a good chance to streamline the use of both interfaces, and fix-up some poor memory management -- the end-points are only activated _once_ per-session.
