### PR TITLE
OSC Client: *new* leverage external libs for OSC messaging

### DIFF
--- a/OSC Client/script.py
+++ b/OSC Client/script.py
@@ -182,7 +182,7 @@ def write_osc_file(content):
   try:
     Stream.writeFully(dstFile, content.encode("utf-8"))
     console.info('"OSC.py" dependency retrieved, restarting node...')
-    call(lambda: _node.restart(), delay = 1) # need a brief pause to allow the file to be written
+    call(lambda: _node.restart(), delay = 2.5) # need a brief pause to allow the file to be written
   except Exception, e:
     console.error('Failed to write the OSC.py file: ', e)
 

--- a/OSC Client/script.py
+++ b/OSC Client/script.py
@@ -1,0 +1,138 @@
+'''OSC Client Node'''
+
+'''
+https://www.music.mcgill.ca/~gary/306/week9/osc.html
+
+An OSC message has the following general format:
+<address pattern>   <type tag string>   <arguments>
+
+The address pattern is a string that starts with a '/', followed by a message routing or destination.
+
+OSC addresses follow a URL or directory tree structure, such as /voices/synth1/osc1/modfreq.
+'''
+
+### Libraries required by this Node
+import OSC
+
+
+### Parameters used by this Node
+DEFAULT_IPADDRESS = "127.0.0.1"
+DEFAULT_PORT = 9000
+
+param_ipAddress = Parameter({'title': 'IP address', 'schema': {'type': 'string', 'hint': DEFAULT_IPADDRESS}, 'order':next_seq()})
+param_port = Parameter({'title': 'Port', 'schema': {'type': 'integer', 'hint': DEFAULT_PORT}, 'order':next_seq()})
+
+param_patterns = Parameter({'title': 'Patterns', 'order': next_seq(), 'schema': {'type': 'array', 'items': {
+        'type': 'object', 'title': 'Pattern', 'properties': {
+          'label': {'type': 'string', 'title': 'Label', 'hint': 'Foobar', 'order': next_seq()},
+          'address': {'type': 'string', 'title': 'Address', 'hint': '/foo/bar', 'order': next_seq()}                                                             
+        } } } })
+
+
+### Functions used by this Node
+def get_float(arg):
+  # cust to reduce integers to decimal
+  if arg > 1:
+    arg = float(arg)
+    arg = arg / 100
+  return arg
+
+def create_client_action(pattern):
+
+  def default_handler(arg):
+    oscmsg = OSC.OSCMessage()
+    oscmsg.setAddress(pattern['address'])
+    if arg:
+      if isinstance(arg, int):
+        arg = get_float(arg) # last minute have to add this, remove from generic client
+      else:
+        arg = get_number(arg)
+      oscmsg.append(arg)
+
+    console.log('Sending [ %s ] to [ %s ].' % (arg, pattern['address']))
+    udp.send(oscmsg.getBinary())
+
+  create_local_action(
+    name='%s' % pattern['label'],
+    metadata=basic_meta('%s' % pattern['label'], '%s' % pattern['address']),
+    handler=default_handler
+  )
+
+
+### UDP utility utilised by this Node
+udp = UDP(ready = lambda: console.info('UDP ready. %s' % udp.getDest()))
+
+
+### Main
+def main(arg = None):
+  print 'Nodel script started.'
+
+  udp.setDest((param_ipAddress or DEFAULT_IPADDRESS) + ':' + str(param_port or DEFAULT_PORT))
+
+  # Generate pattern-matching local actions
+  if not is_empty(param_patterns):
+    for pattern in param_patterns:
+      create_client_action(pattern)
+
+### Utilities
+def basic_meta(label, address):
+  return {
+    'title': '%s' % label,
+    'group': 'Patterns',
+    'order': next_seq(),
+    'schema': {
+      'type': 'string',
+      'title': '%s' % address
+    }
+  }
+
+def get_number(s):
+  if is_number(s):
+    return int(s) if s.isdecimal() else float(s)
+  else:
+    return s
+
+def is_number(s):
+    try:
+        float(s)
+        return True
+    except ValueError:
+        return False
+      
+# Customisation
+def meta(name):
+  console.log('Creating %s action.' % name.lower())
+  return {
+      'title': name,
+      'schema': {
+          'type': 'string',
+          'enum': ['On', 'Off']
+      },
+      'order': next_seq(),
+      'group': name
+  }
+  
+def handlePower(arg):
+  if arg =='On':
+    lookup_local_action('Play').call()
+    lookup_local_event('Power').emit('On')
+  elif arg =='Off':
+    lookup_local_action('Pause').call()
+    lookup_local_event('Power').emit('Off')
+      
+create_local_action('Power', handlePower, meta('Power'))
+
+def handleMuting(arg):
+  if arg =='On':
+    lookup_local_action('Power').call('Off')
+  elif arg =='Off':
+    lookup_local_action('Power').call('On')
+      
+create_local_action('Muting', handleMuting, meta('Muting'))
+
+local_event_Power = LocalEvent({"title":"Power","schema":{"type":"string", "enum":['On','Off']},"group":"Power","order": next_seq()})
+
+# vol cust
+local_event_Volume = LocalEvent({"title":"Volume","schema":{"type":"integer"},"group":"Volume","order": next_seq()})
+  
+

--- a/OSC Client/script.py
+++ b/OSC Client/script.py
@@ -2,6 +2,11 @@
 OSC Client Node
 
 `rev 2 2023.02.07`
+
+- Unidirectional only.
+- Turn OSC messages (address pattern + optional argument) into local actions via parameters.
+- Send custom OSC messages via a custom local action.
+
 '''
 
 '''

--- a/OSC Client/script.py
+++ b/OSC Client/script.py
@@ -15,10 +15,8 @@ The address pattern is a string that starts with a '/', followed by a message ro
 OSC addresses follow a URL or directory tree structure, such as /voices/synth1/osc1/modfreq.
 '''
 
-# Libraries required by this Node
+# <-- parameters
 
-
-# Parameters used by this Node
 import os                          # working directory
 from java.io import File           # reading files
 from org.nodel.io import Stream    # reading files
@@ -37,15 +35,10 @@ param_patterns = Parameter({'title': 'Patterns', 'order': next_seq(), 'schema': 
         'address': {'type': 'string', 'title': 'Address', 'hint': '/foo/bar', 'order': next_seq()}
     }}}})
 
+# -->
 
-# Functions used by this Node
-def get_float(arg):
-  # cust to reduce integers to decimal
-  if arg > 1:
-    arg = float(arg)
-    arg = arg / 100
-  return arg
 
+# <-- functions
 
 def create_client_action(pattern):
 
@@ -68,6 +61,8 @@ def create_client_action(pattern):
       metadata=basic_meta('%s' % pattern['label'], '%s' % pattern['address']),
       handler=default_handler
   )
+
+# -->
 
 
 # <-- UDP
@@ -104,13 +99,18 @@ def basic_meta(label, address):
       }
   }
 
-
 def get_number(s):
   if is_number(s):
     return int(s) if s.isdecimal() else float(s)
   else:
     return s
-
+  
+def get_float(arg):
+  # cust to reduce integers to decimal
+  if arg > 1:
+    arg = float(arg)
+    arg = arg / 100
+  return arg
 
 def is_number(s):
     try:

--- a/OSC Client/script.py
+++ b/OSC Client/script.py
@@ -17,12 +17,13 @@ OSC addresses follow a URL or directory tree structure, such as /voices/synth1/o
 
 # <-- parameters
 
-import os                          # working directory
-from java.io import File           # reading files
-from org.nodel.io import Stream    # reading files
-from org.nodel.core import Nodel   # for host path
+from java.io import File
+from org.nodel.io import Stream
+
 DEFAULT_IPADDRESS = "127.0.0.1"
 DEFAULT_PORT = 9000
+
+DEFAULT_PATTERN = "/foo/bar"
 
 param_ipAddress = Parameter({'title': 'IP address', 'schema': {
                             'type': 'string', 'hint': DEFAULT_IPADDRESS}, 'order': next_seq()})
@@ -37,14 +38,18 @@ param_patterns = Parameter({'title': 'Patterns', 'order': next_seq(), 'schema': 
 
 # -->
 
-
 # <-- functions
 
+# batch local actions sending OSC messages based on parameter patterns
 def create_client_action(pattern):
 
   def default_handler(arg):
+    
+    # address pattern
     oscmsg = OSC.OSCMessage()
     oscmsg.setAddress(pattern['address'])
+
+    # optional argument
     if arg:
       if isinstance(arg, int):
         # last minute have to add this, remove from generic client
@@ -53,6 +58,7 @@ def create_client_action(pattern):
         arg = get_number(arg)
       oscmsg.append(arg)
 
+    # send
     console.log('Sending [ %s ] to [ %s ].' % (arg, pattern['address']))
     udp.send(oscmsg.getBinary())
 
@@ -62,8 +68,38 @@ def create_client_action(pattern):
       handler=default_handler
   )
 
-# -->
+# a custom action for sending arbitrary OSC messages
+def create_custom_action():
 
+  def generic_osc_handler(message):
+    if message != None:
+
+      # address pattern
+      address = (message['address'] or DEFAULT_PATTERN).strip()
+      oscmsg = OSC.OSCMessage()
+      oscmsg.setAddress(address)
+
+      # optional argument
+      arg = None
+      if message['arg']:
+        if isinstance(message['arg'], int):
+          arg = get_float(message['arg'])
+        else:
+          arg = get_number(message['arg'])
+        oscmsg.append(arg)
+
+      # send
+      console.log('Sending [ %s ] to [ %s ].' % (arg, address))
+      udp.send(oscmsg.getBinary())
+
+  custom_metadata = {'group': 'Custom', 'title': 'Send a custom message', 'schema': {'type': 'object', 'properties': {
+      'address': {'type': 'string', 'title': 'Address', 'hint': DEFAULT_PATTERN, 'order': next_seq()},
+      'arg': {'type': 'string', 'title': 'Argument', 'hint': '1', 'order': next_seq()}
+  }}, 'order': next_seq()}
+  
+  create_local_action('Custom', handler=generic_osc_handler, metadata=custom_metadata)
+
+# -->
 
 # <-- UDP
 
@@ -74,12 +110,15 @@ udp = UDP(ready=lambda: console.info('UDP ready. %s' % udp.getDest()))
 # <-- main
 
 def main(arg=None):
-  print 'Nodel script started.'
+  console.log('Nodel script started.')
 
   udp.setDest((param_ipAddress or DEFAULT_IPADDRESS) +
               ':' + str(param_port or DEFAULT_PORT))
+  
+  # Create a generic local actions for sending custom OSC messages
+  create_custom_action()
 
-  # Generate pattern-matching local actions
+  # Generate any user specified pattern-matching local actions from parameters
   if not is_empty(param_patterns):
     for pattern in param_patterns:
       create_client_action(pattern)
@@ -104,9 +143,8 @@ def get_number(s):
     return int(s) if s.isdecimal() else float(s)
   else:
     return s
-  
+
 def get_float(arg):
-  # cust to reduce integers to decimal
   if arg > 1:
     arg = float(arg)
     arg = arg / 100
@@ -121,54 +159,8 @@ def is_number(s):
     
 # -->
 
-# <-- customisation
-
-def meta(name):
-  console.log('Creating %s action.' % name.lower())
-  return {
-      'title': name,
-      'schema': {
-          'type': 'string',
-          'enum': ['On', 'Off']
-      },
-      'order': next_seq(),
-      'group': name
-  }
-
-
-def handlePower(arg):
-  if arg == 'On':
-    lookup_local_action('Play').call()
-    lookup_local_event('Power').emit('On')
-  elif arg == 'Off':
-    lookup_local_action('Pause').call()
-    lookup_local_event('Power').emit('Off')
-
-
-create_local_action('Power', handlePower, meta('Power'))
-
-
-def handleMuting(arg):
-  if arg == 'On':
-    lookup_local_action('Power').call('Off')
-  elif arg == 'Off':
-    lookup_local_action('Power').call('On')
-
-
-create_local_action('Muting', handleMuting, meta('Muting'))
-
-local_event_Power = LocalEvent({"title": "Power", "schema": {
-                               "type": "string", "enum": ['On', 'Off']}, "group": "Power", "order": next_seq()})
-
-# vol cust
-local_event_Volume = LocalEvent({"title": "Volume", "schema": {
-                                "type": "integer"}, "group": "Volume", "order": next_seq()})
-
-# -->
-
 # <-- retrieve and write OSC dependency
 PYOSC_URL = 'https://raw.githubusercontent.com/ptone/pyosc/master/OSC.py'
-
 
 def retrieve_osc_dependency():
   resp = get_url(PYOSC_URL, fullResponse=True)
@@ -178,7 +170,6 @@ def retrieve_osc_dependency():
 
   return resp.content
 
-
 def write_osc_file(content):
   rootDir = File(_node.getRoot(), '')
   dstFile = File(rootDir, 'OSC.py')
@@ -186,13 +177,13 @@ def write_osc_file(content):
   try:
     Stream.writeFully(dstFile, content.encode("utf-8"))
     console.info('"OSC.py" dependency retrieved, restarting node...')
-    _node.restart()
+    call(lambda: _node.restart(), delay = 1) # need a brief pause to allow the file to be written
   except Exception, e:
     console.error('Failed to write the OSC.py file: ', e)
 
-
 @after_main
 def check_for_osc_dependency():
+  global OSC
   try:
     import OSC
   except ImportError:


### PR DESCRIPTION
Years ago I thought of adding support for OSC to the toolkit but opted instead to just write a couple of recipes which handled it using a pure Python library called [pyOSC](https://github.com/ptone/pyosc).

See https://github.com/museumsvictoria/nodel/issues/135

I've since heard of numerous cases of people using this recipe to interface with typical multimedia software such as Watchout and Max and figured we might as well just make it official.

The one hesitation I had at the time was that the library was too big at 88 KB. It would put this recipe up there in the top 10 largest recipes in the repo. The years have wisened me and my compromise has been to add a small function to automatically download the library rather than storing it in the repo itself.

#### Features
![osc-client-demo](https://user-images.githubusercontent.com/9277107/217114433-3800b335-7761-472c-bb69-3857b622beeb.gif)

- Unidirectional only.
- Turn OSC messages (address pattern + optional argument) into local actions via parameters.
- Send custom OSC messages via a custom local action.
