### PR TITLE
Issue #78 Fix handling of plain backslashes

### DIFF
--- a/App Launcher/script.py
+++ b/App Launcher/script.py
@@ -361,32 +361,30 @@ def decodeArgList(argsString):
   
   escaping = False
   quoting = False
-  specialQuoting = False
   
   currentArg = list()
   
   for c in argsString:
-    if escaping and not specialQuoting:
+    if escaping:
       escaping = False
-
-      if c == ' ' or c == '"' or c == "'": # put these away immediately (space-delimiter or quote)
-        currentArg.append(c)
-        continue      
-      
-    if c == '\\' and not specialQuoting:
+      currentArg.append('\\') # Add the backslash first
+      currentArg.append(c) # Add the escaped character
+      continue
+    
+    if c == '\\':
       escaping = True
       continue
-      
+    
     # not escaping or dealt with special characters, can deal with any char now
     
-    if c == ' ': # delimeter?
-      if not quoting and not specialQuoting: 
-        # hit the space delimeter (outside of quotes)
+    if c == ' ': # delimiter?
+      if not quoting:
+        # hit the space delimiter (outside of quotes)
         if len(currentArg) > 0:
           argsList.append(''.join(currentArg))
           del currentArg[:]
-          continue
-
+        continue
+    
     if c == ' ' and len(currentArg) == 0: # don't fill up with spaces
       pass
     else:
@@ -395,26 +393,16 @@ def decodeArgList(argsString):
     if c == '"': # quoting?
       if quoting: # close quote
         quoting = False
-        argsList.append(''.join(currentArg))
-        del currentArg[:]
+        if len(currentArg) > 0:
+          argsList.append(''.join(currentArg))
+          del currentArg[:]
         continue
-        
       else:
         quoting = True # open quote
   
-    if c == "'": # special quoting?
-      if specialQuoting: # close quote
-        specialQuoting = False
-        argsList.append(''.join(currentArg))
-        del currentArg[:]
-        continue
-        
-      else:
-        specialQuoting = True # open quote
-  
   if len(currentArg) > 0:
-      argsList.append(''.join(currentArg))
-
+    argsList.append(''.join(currentArg))
+  
   return argsList
 
 

--- a/App Launcher/script.py
+++ b/App Launcher/script.py
@@ -361,25 +361,26 @@ def decodeArgList(argsString):
   
   escaping = False
   quoting = False
+  specialQuoting = False
   
   currentArg = list()
   
   for c in argsString:
-    if escaping:
+    if escaping and not specialQuoting:
       escaping = False
 
-      if c == ' ' or c == '"': # put these away immediately (space-delimiter or quote)
+      if c == ' ' or c == '"' or c == "'": # put these away immediately (space-delimiter or quote)
         currentArg.append(c)
         continue      
       
-    if c == '\\':
+    if c == '\\' and not specialQuoting:
       escaping = True
       continue
       
     # not escaping or dealt with special characters, can deal with any char now
     
     if c == ' ': # delimeter?
-      if not quoting: 
+      if not quoting and not specialQuoting: 
         # hit the space delimeter (outside of quotes)
         if len(currentArg) > 0:
           argsList.append(''.join(currentArg))
@@ -400,6 +401,16 @@ def decodeArgList(argsString):
         
       else:
         quoting = True # open quote
+  
+    if c == "'": # special quoting?
+      if specialQuoting: # close quote
+        specialQuoting = False
+        argsList.append(''.join(currentArg))
+        del currentArg[:]
+        continue
+        
+      else:
+        specialQuoting = True # open quote
   
   if len(currentArg) > 0:
       argsList.append(''.join(currentArg))


### PR DESCRIPTION
I've noticed that escaping behaves a little unexpectedly for example with the following parameters, I get two different results.

![image](https://github.com/museumsvictoria/nodel-recipes/assets/9277107/5dac9291-b438-46ca-97c9-93309aa7618f)
👇

```json
nodeConfig.json
"AppPath": "C:\\Program Files\\VideoLAN\\VLC\\vlc.exe",
"AppArgs": "C:\\content\\MLK.mp4"
```
👇
`Full command-line: [C:\Program Files\VideoLAN\VLC\vlc.exe C:contentMLK.mp4]` _(notice the AppArgs have been sanitised)_

---

The behaviour on, for example, PowerShell is that auto completion uses apostrophes to protect strings.

This PR suggests adding the same special case such that I'm able to retain backslashes in my App. Args if I enclose them in apostrophes I retain the string as it is typed into the parameter.

![image](https://github.com/museumsvictoria/nodel-recipes/assets/9277107/a35c9852-d633-4381-bc79-153c022e4967)
👇
```json
nodeConfig.json
"AppArgs": "'C:\\content\\MLK.mp4'"
```
👇

`Full command-line: [C:\Program Files\VideoLAN\VLC\vlc.exe 'C:\content\MLK.mp4']`