### PR TITLE
Windows 10 computer controller: add screenshot timestamp toggle

### DIFF
--- a/Computer Controller/Windows 10/ComputerController.cs
+++ b/Computer Controller/Windows 10/ComputerController.cs
@@ -11,6 +11,8 @@ using System.Management;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
 
+// rev. 5: toggleable screenshot timestamp overlay
+//
 // rev. 4: gracefully handles missing audio hardware
 //   - if missing at start, will check every min for presence
 //   - if found but then goes missing/problematic, will gracefully shutdown avoiding
@@ -21,6 +23,7 @@ using System.Collections.Generic;
 class ComputerController
 {
     static bool s_running = true;
+    static bool s_showTimestamp = true;
 
     static void Main(string[] args)
     {
@@ -58,6 +61,7 @@ class ComputerController
         Console.WriteLine("// set-volume");
         Console.WriteLine("// get-volumescalar (0.0 - 100.0)");
         Console.WriteLine("// set-volumescalar");
+        Console.WriteLine("// set-timestamp (true or false)");
         Console.WriteLine("// q");
     }
 
@@ -120,6 +124,11 @@ class ComputerController
                     Audio.VolumeScalar = value;
                     s_volumeScalar = value;
                     EmitVolumeScalar();
+                    break;
+
+                case "set-timestamp":
+                    arg = parts[1];
+                    s_showTimestamp = arg == "true";
                     break;
 
                 case "q":
@@ -507,6 +516,20 @@ class ComputerController
                 screenshotGraphics.CopyFromScreen(screen.Bounds.X, screen.Bounds.Y, 0, 0, screen.Bounds.Size, CopyPixelOperation.SourceCopy);
 
                 Image newImage = ScaleImage(screenshot, 400, 400);
+
+                // burn timestamp into image (toggleable)
+                if (s_showTimestamp)
+                {
+                    using (var g = Graphics.FromImage(newImage))
+                    {
+                        var text = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+                        using (var font = new Font("Consolas", 10, FontStyle.Bold))
+                        {
+                            g.DrawString(text, font, Brushes.Black, 5, newImage.Height - 19);
+                            g.DrawString(text, font, Brushes.White, 4, newImage.Height - 20);
+                        }
+                    }
+                }
 
                 // Other types
                 // screenshot.Save("screen" + i + ".jpg", GetEncoderInfo("image/jpeg"), p);

--- a/Computer Controller/Windows 10/script.py
+++ b/Computer Controller/Windows 10/script.py
@@ -1,7 +1,7 @@
 '''
 **PC agent** with native Windows operations, tested with Windows 10 but might work on older or newer versions. 
 
-`REV 4.20251028`
+`REV 5.20260302`
 
 Includes:
 
@@ -14,13 +14,16 @@ Includes:
 
 **REVISION HISTORY**
 
-* rev. 4: add ability to lock device 
+* rev. 5: add screenshot timestamp overlay toggle
+* rev. 4: add ability to lock device
 
 '''
 
 DEFAULT_FREESPACEMB = 0.5
 
 param_FreeSpaceThreshold = Parameter({ 'title': 'Freespace threshold (GB)', 'schema': { 'type': 'integer', 'hint': '(default %s)' % DEFAULT_FREESPACEMB }})
+
+param_ScreenshotTimestamp = Parameter({ 'title': 'Show timestamp on screenshots', 'group': 'Screenshots', 'schema': { 'type': 'boolean', 'hint': '(default true)' }})
 
 # <!-- CPU
 
@@ -228,6 +231,7 @@ def controller_started():
   _controller.send('get-mute')
   _controller.send('get-volume')
   _controller.send('get-volumescalar')
+  _controller.send('set-timestamp %s' % ('true' if param_ScreenshotTimestamp != False else 'false'))
 
 _controller = Process([ '%s\\ComputerController.exe' % _node.getRoot().getAbsolutePath() ], 
                      stdout=controller_feedback, 


### PR DESCRIPTION
Adds a toggle for timestamp text on screenshot thumbnails in the Windows 10 recipe.

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/35d33c45-3c65-447f-aba1-a7b0d6a136e6" />

- script.py: new `Show timestamp on screenshots` parameter; sends `set-timestamp true|false` on controller start.
- ComputerController.cs: adds `set-timestamp` command; draws timestamp only when enabled.
- Bumps revision to `REV 5.20260302`.