### PR TITLE
feat: add UDP receiver

### DIFF
--- a/UDP Receiver/ingredient_MessageEvents.py
+++ b/UDP Receiver/ingredient_MessageEvents.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+# Create a local event for each configured, expected UDP message.
+
+from org.nodel import SimpleName
+
+
+param_messageEvents = Parameter({
+    'title': 'Message events',
+    'desc': 'Create events for expected messages. Matching is case-sensitive and ignores trailing CR/LF characters.',
+    'schema': {
+        'type': 'array',
+        'items': {
+            'type': 'object',
+            'properties': {
+                'message': {
+                    'title': 'Expected message',
+                    'type': 'string',
+                    'required': True,
+                    'order': 1
+                },
+                'event': {
+                    'title': 'Event name',
+                    'type': 'string',
+                    'required': True,
+                    'order': 2
+                },
+                'value': {
+                    'title': 'Event value',
+                    'type': 'string',
+                    'hint': '(defaults to the expected message)',
+                    'order': 3
+                }
+            }
+        }
+    },
+    'default': [],
+    'order': 5
+})
+
+
+local_event_MatchedCount = LocalEvent({
+    'group': 'Status',
+    'order': 20,
+    'schema': {'type': 'integer', 'minimum': 0}
+})
+
+local_event_UnmatchedCount = LocalEvent({
+    'group': 'Status',
+    'order': 21,
+    'schema': {'type': 'integer', 'minimum': 0}
+})
+
+local_event_MessageEventStatus = LocalEvent({
+    'group': 'Status',
+    'order': 9991,
+    'schema': {
+        'type': 'object',
+        'properties': {
+            'level': {'type': 'integer'},
+            'message': {'type': 'string'}
+        }
+    }
+})
+
+
+_messageMappings = {}
+_matchedCount = 0
+_unmatchedCount = 0
+
+
+def _normalise_message(message):
+    return str(message).rstrip('\r\n')
+
+
+def _validate_message_events():
+    specs = []
+    messages = {}
+    event_names = {}
+
+    for index, item in enumerate(param_messageEvents or []):
+        row = index + 1
+        if not hasattr(item, 'get'):
+            return None, 'Message event row %s must be an object' % row
+
+        message = item.get('message')
+        if not isinstance(message, basestring):
+            return None, 'Message event row %s requires a string message' % row
+        message = _normalise_message(message)
+        if len(message) == 0:
+            return None, 'Message event row %s has an empty message' % row
+        if message in messages:
+            return None, 'Message event rows %s and %s have the same message' % (
+                messages[message], row)
+
+        event_name = item.get('event')
+        if not isinstance(event_name, basestring):
+            return None, 'Message event row %s requires a string event name' % row
+        event_name = event_name.strip()
+        if len(event_name) == 0:
+            return None, 'Message event row %s has an empty event name' % row
+
+        simple_name = SimpleName(event_name).getReducedForMatchingName()
+        if len(simple_name) == 0:
+            return None, 'Message event row %s has an invalid event name' % row
+        if simple_name in event_names:
+            return None, 'Message event rows %s and %s have equivalent event names' % (
+                event_names[simple_name], row)
+        if lookup_local_event(event_name) is not None:
+            return None, 'Message event row %s collides with existing event %s' % (
+                row, event_name)
+
+        value = item.get('value')
+        if value is None or value == '':
+            value = message
+        elif not isinstance(value, basestring):
+            return None, 'Message event row %s has a non-string event value' % row
+
+        messages[message] = row
+        event_names[simple_name] = row
+        specs.append({
+            'message': message,
+            'eventName': event_name,
+            'value': str(value),
+            'order': row
+        })
+
+    return specs, None
+
+
+def _route_message_event(datagram):
+    global _matchedCount, _unmatchedCount
+
+    raw_message = datagram['message']
+    message = _normalise_message(raw_message)
+    mapping = _messageMappings.get(message)
+
+    if mapping is None:
+        _unmatchedCount += 1
+        local_event_UnmatchedCount.emit(_unmatchedCount)
+        log(1, 'Unmatched UDP message from %s: %s' % (
+            datagram['source'], repr(raw_message)))
+        return
+
+    _matchedCount += 1
+    local_event_MatchedCount.emit(_matchedCount)
+    mapping['event'].emit(mapping['value'])
+    log(2, 'Matched UDP message from %s to event %s with value %s' % (
+        datagram['source'], mapping['eventName'], repr(mapping['value'])))
+
+
+_register_datagram_handler(_route_message_event)
+
+
+@after_main
+def setup_message_events():
+    global _messageMappings, _matchedCount, _unmatchedCount
+
+    _messageMappings = {}
+    _matchedCount = 0
+    _unmatchedCount = 0
+    local_event_MatchedCount.emit(0)
+    local_event_UnmatchedCount.emit(0)
+
+    specs, error = _validate_message_events()
+    if error is not None:
+        message = 'Invalid message events: %s' % error
+        console.error(message)
+        local_event_MessageEventStatus.emit({'level': 2, 'message': message})
+        return
+
+    for spec in specs:
+        event = create_local_event(spec['eventName'], {
+            'group': 'Message Events',
+            'order': spec['order'],
+            'schema': {'type': 'string'}
+        })
+        _messageMappings[spec['message']] = {
+            'event': event,
+            'eventName': spec['eventName'],
+            'value': spec['value']
+        }
+
+    if len(specs) == 0:
+        message = 'No message mappings configured'
+    else:
+        message = '%s message mapping%s active' % (
+            len(specs), '' if len(specs) == 1 else 's')
+
+    local_event_MessageEventStatus.emit({'level': 0, 'message': message})

--- a/UDP Receiver/readme.md
+++ b/UDP Receiver/readme.md
@@ -1,0 +1,82 @@
+# UDP Receiver
+
+Receives UTF-8 UDP datagrams and maps expected messages to generated Nodel
+events. Source filtering, validation and message routing remain separate from
+any downstream action bindings.
+
+## Sender setup
+
+Set the sender's UDP target host to the Nodel host and its target port to the
+receiver's configured port. Each datagram is handled as one complete message.
+
+The receiver defaults to port `12345`. Prefer a specific host address over
+broadcast.
+
+## Message events
+
+The enabled `ingredient_MessageEvents.py` adds a **Message events** parameter.
+Each row contains:
+
+- `message`: required expected UDP message.
+- `event`: required local event name.
+- `value`: optional string emitted by the event; defaults to `message`.
+
+For example:
+
+```json
+{
+  "message": "TRIGGER_ON",
+  "event": "Trigger On",
+  "value": "On"
+}
+```
+
+Matching is case-sensitive. Trailing CR and LF characters are ignored, so
+`TRIGGER_ON`, `TRIGGER_ON\n`, and `TRIGGER_ON\r\n` match the same mapping. Every
+matching datagram emits, including consecutive identical messages. The event's
+normal Nodel timestamp is its last-received time.
+
+An empty mapping list is valid. Invalid rows, duplicate normalized messages,
+equivalent event names, or collisions with existing events disable all mapped
+events and set `MessageEventStatus` to an error; the UDP listener keeps running.
+
+## Nodel events
+
+- Generated events: one string event per valid message mapping, grouped under
+  **Message Events**.
+- `ReceivedCount`: all accepted datagrams.
+- `MatchedCount` and `UnmatchedCount`: accepted routing outcomes;
+  `ReceivedCount = MatchedCount + UnmatchedCount`.
+- `RejectedCount` and `LastRejected`: source or payload validation failures.
+- `Status`: listener startup or configuration failure.
+- `MessageEventStatus`: mapping configuration health.
+
+Counters reset when the node starts.
+
+## Logging
+
+Use `RaiseLogLevel` and `LowerLogLevel` under **Debug**:
+
+- Level `0`: lifecycle and genuine configuration/startup errors only.
+- Level `1`: unmatched accepted messages, with source and escaped payload.
+- Level `2`: all accepted routing details and rejection reasons.
+
+Payloads are escaped in the log so line endings remain visible. Raw messages
+are deliberately not exposed as always-visible Nodel events.
+
+Use `Allowed source addresses` before connecting events to physical actions. The
+allowlist compares sender IP addresses only; UDP sender ports are intentionally
+ephemeral.
+
+UDP does not acknowledge or guarantee delivery. Keep downstream commands
+idempotent when practical.
+
+## Site-specific name
+
+The script identifies itself as `UDP Receiver`. A node-local custom script can
+change that presentation without modifying the shared recipe. For example,
+`custom_Exhibit.py` can contain:
+
+```python
+_receiverName = 'Exhibit UDP Receiver'
+```

--- a/UDP Receiver/script.py
+++ b/UDP Receiver/script.py
@@ -1,0 +1,284 @@
+# coding=utf-8
+'''
+**UDP datagram receiver** with source filtering, message routing and tiered diagnostics.
+
+`REV 2.20260817`
+
+Includes:
+
+* configurable bind address and UDP port
+* optional IPv4 source allowlist
+* message length and basic payload validation
+* receive and rejection counters with operational status
+* adjustable console logging for packet diagnostics
+* message-to-event routing through `ingredient_MessageEvents.py`
+
+**REVISION HISTORY**
+
+* rev. 2: add tiered logging and the message-handler ingredient contract
+* rev. 1: initial release
+
+'''
+
+import sys
+
+
+# May be overridden by an ingredient_*.py or custom_*.py script.
+_receiverName = 'UDP Receiver'
+
+
+param_bindAddress = Parameter({
+    'title': 'Bind address',
+    'desc': 'Local interface to listen on. Use 0.0.0.0 for all IPv4 interfaces.',
+    'schema': {'type': 'string', 'hint': '0.0.0.0 (default)'},
+    'default': '0.0.0.0',
+    'order': 1
+})
+
+param_port = Parameter({
+    'title': 'UDP port',
+    'schema': {
+        'type': 'integer',
+        'minimum': 1,
+        'maximum': 65535,
+        'hint': '12345 (default)'
+    },
+    'default': 12345,
+    'order': 2
+})
+
+param_allowedSources = Parameter({
+    'title': 'Allowed source addresses',
+    'desc': 'Exact IPv4 addresses allowed to emit events. An empty list accepts any source.',
+    'schema': {'type': 'array', 'items': {'type': 'string'}},
+    'default': [],
+    'order': 3
+})
+
+param_maximumMessageLength = Parameter({
+    'title': 'Maximum message length',
+    'desc': 'Longer datagrams are rejected before their content is emitted.',
+    'schema': {
+        'type': 'integer',
+        'minimum': 1,
+        'maximum': 65535,
+        'hint': '1024 bytes (default)'
+    },
+    'default': 1024,
+    'order': 4
+})
+
+
+local_event_ReceivedCount = LocalEvent({
+    'group': 'Status',
+    'order': 10,
+    'schema': {'type': 'integer', 'minimum': 0}
+})
+
+local_event_RejectedCount = LocalEvent({
+    'group': 'Status',
+    'order': 11,
+    'schema': {'type': 'integer', 'minimum': 0}
+})
+
+local_event_LastRejected = LocalEvent({
+    'group': 'Status',
+    'order': 12,
+    'schema': {
+        'type': 'object',
+        'properties': {
+            'source': {'type': 'string'},
+            'reason': {'type': 'string'},
+            'receivedAt': {'type': 'string'}
+        }
+    }
+})
+
+local_event_Status = LocalEvent({
+    'group': 'Status',
+    'order': 9990,
+    'schema': {
+        'type': 'object',
+        'properties': {
+            'level': {'type': 'integer'},
+            'message': {'type': 'string'}
+        }
+    }
+})
+
+local_event_LogLevel = LocalEvent({
+    'group': 'Debug',
+    'order': 10000,
+    'desc': 'Raise this to show progressively more UDP packet detail in the console.',
+    'schema': {'type': 'integer', 'minimum': 0, 'maximum': 2}
+})
+
+
+@local_action({'group': 'Debug', 'order': 10001})
+def RaiseLogLevel(arg=None):
+    level = local_event_LogLevel.getArg() or 0
+    local_event_LogLevel.emit(min(level + 1, 2))
+
+
+@local_action({'group': 'Debug', 'order': 10002})
+def LowerLogLevel(arg=None):
+    level = local_event_LogLevel.getArg() or 0
+    local_event_LogLevel.emit(max(level - 1, 0))
+
+
+def log(level, message):
+    if (local_event_LogLevel.getArg() or 0) >= level:
+        console.log(('  ' * level) + message)
+
+
+_receiver = None
+_allowedSources = []
+_maximumMessageLength = 1024
+_receivedCount = 0
+_rejectedCount = 0
+_datagramHandlers = []
+
+
+def _register_datagram_handler(handler):
+    if handler not in _datagramHandlers:
+        _datagramHandlers.append(handler)
+
+
+def _dispatch_datagram(datagram):
+    for handler in list(_datagramHandlers):
+        try:
+            handler(datagram)
+        except:
+            error = sys.exc_info()[1]
+            console.error('UDP datagram handler failed: %s' % error)
+
+
+def _source_address(source):
+    value = str(source).strip()
+    if value.startswith('/'):
+        value = value[1:]
+
+    split = value.rfind(':')
+    if split > 0:
+        value = value[:split]
+
+    if value.startswith('[') and value.endswith(']'):
+        value = value[1:-1]
+
+    return value
+
+
+def _reject(source, reason):
+    global _rejectedCount
+    _rejectedCount += 1
+    received_at = str(date_now())
+    local_event_RejectedCount.emit(_rejectedCount)
+    local_event_LastRejected.emit({
+        'source': str(source),
+        'reason': reason,
+        'receivedAt': received_at
+    })
+    log(2, 'Rejected UDP datagram from %s: %s' % (source, reason))
+
+
+def _received(source, data):
+    global _receivedCount
+
+    source_address = _source_address(source)
+    if len(_allowedSources) > 0 and source_address not in _allowedSources:
+        _reject(source, 'Source address is not allowed')
+        return
+
+    if data is None or len(data) == 0:
+        _reject(source, 'Message is empty')
+        return
+
+    if len(data) > _maximumMessageLength:
+        _reject(source, 'Message exceeds the configured maximum length')
+        return
+
+    if '\x00' in data:
+        _reject(source, 'Message contains a null character')
+        return
+
+    _receivedCount += 1
+    received_at = str(date_now())
+    source_text = str(source)
+
+    datagram = {
+        'sequence': _receivedCount,
+        'source': source_text,
+        'message': data,
+        'receivedAt': received_at
+    }
+
+    local_event_ReceivedCount.emit(_receivedCount)
+    log(2, 'Accepted UDP datagram from %s: %s' % (source_text, repr(data)))
+    _dispatch_datagram(datagram)
+
+
+def _ready():
+    bind_address = (param_bindAddress or '0.0.0.0').strip()
+    source_policy = 'any source'
+    if len(_allowedSources) > 0:
+        source_policy = ', '.join(_allowedSources)
+    message = 'Listening on %s:%s; allowed: %s' % (
+        bind_address, param_port or 12345, source_policy)
+    console.info(message)
+    local_event_ReceivedCount.emit(0)
+    local_event_RejectedCount.emit(0)
+    local_event_Status.emit({'level': 0, 'message': message})
+
+
+def main(arg=None):
+    console.info('%s loading' % _receiverName)
+
+
+@after_main
+def start_receiver():
+    global _receiver, _allowedSources, _maximumMessageLength
+
+    bind_address = (param_bindAddress or '0.0.0.0').strip()
+    port = int(12345 if param_port is None else param_port)
+    maximum_length = int(1024 if param_maximumMessageLength is None else param_maximumMessageLength)
+
+    if local_event_LogLevel.getArg() is None:
+        local_event_LogLevel.emit(0)
+
+    if len(bind_address) == 0:
+        bind_address = '0.0.0.0'
+    if port < 1 or port > 65535:
+        local_event_Status.emit({'level': 2, 'message': 'UDP port must be between 1 and 65535'})
+        return
+    if maximum_length < 1 or maximum_length > 65535:
+        local_event_Status.emit({'level': 2, 'message': 'Maximum message length must be between 1 and 65535'})
+        return
+
+    _allowedSources = []
+    for source in param_allowedSources or []:
+        source = str(source).strip()
+        if len(source) > 0 and source not in _allowedSources:
+            _allowedSources.append(source)
+    _maximumMessageLength = maximum_length
+
+    try:
+        _receiver = UDP(
+            source='%s:%s' % (bind_address, port),
+            dest=None,
+            ready=_ready,
+            received=_received)
+    except:
+        error = sys.exc_info()[1]
+        message = 'Could not start UDP receiver on %s:%s: %s' % (
+            bind_address, port, error)
+        console.error(message)
+        local_event_Status.emit({'level': 2, 'message': message})
+
+
+@at_cleanup
+def stop_receiver():
+    global _receiver
+    if _receiver is not None:
+        _receiver.close()
+        _receiver = None
+    console.info('%s stopped' % _receiverName)


### PR DESCRIPTION

<img width="1866" height="1159" alt="2026-08-18_TTCLy43r@2x" src="https://github.com/user-attachments/assets/42e32e62-57c2-4e26-8bcd-25c6cd922d44" />

Adds a generic UDP receiver recipe that accepts repeated raw datagrams, filters optional source addresses, validates payloads, and reports operational counters without binding directly to downstream actions.

The included message-events ingredient maps configured payloads to generated Nodel events with exact case-sensitive matching, CR/LF tolerance, collision checks, and adjustable packet diagnostics.