### PR TITLE
OSC Client: rev 3 - drop the pyosc dependency and fix argument handling

### DIFF
--- a/OSC Client/script.py
+++ b/OSC Client/script.py
@@ -1,199 +1,482 @@
+# coding=utf-8
 '''
 OSC Client Node
 
-`rev 2 2023.02.07`
+`rev 3 2026.08.17`
 
-- Unidirectional only.
-- Turn OSC messages (address pattern + optional argument) into local actions via parameters.
-- Send custom OSC messages via a custom local action.
+Sends OSC 1.0 messages over UDP, and can optionally listen for replies.
 
+* Turns address patterns into local actions via parameters.
+* Sends arbitrary messages via a custom local action.
+* Optionally binds a receive port and emits inbound messages as events.
+
+OSC encoding is implemented directly against the OSC 1.0 specification, so this
+recipe has no external dependency, no runtime download and no self-restart.
+
+**REVISION HISTORY**
+
+* rev. 3: pure-Jython OSC codec, replacing the pyosc dependency that was fetched
+  from GitHub at startup (the node then restarted itself). Arguments may now be
+  typed, repeated, empty, or literal `0`. Optional receive port with a generic
+  `Received` event and a handler hook for ingredients. Sends are reported
+  through the usual `LogLevel` convention instead of unconditional
+  `console.log`, so a node polling on a timer no longer fills its console.
+
+  **Breaking change:** rev 2 divided any numeric argument greater than 1 by 100,
+  so `5` went on the wire as `0.05`. Arguments are now sent exactly as written.
+  Rigs that relied on the old scaling must send the already-scaled value.
+
+* rev. 2: pattern-driven client, custom message action.
+
+---
+
+An OSC message is:
+
+    <address pattern> <type tag string> <arguments>
+
+Each part is padded to a multiple of 4 bytes. Addresses follow a directory-like
+structure, e.g. `/voices/synth1/osc1/modfreq`.
+
+See http://opensoundcontrol.org/spec-1_0
 '''
 
-'''
-https://www.music.mcgill.ca/~gary/306/week9/osc.html
-
-An OSC message has the following general format:
-<address pattern>   <type tag string>   <arguments>
-
-The address pattern is a string that starts with a '/', followed by a message routing or destination.
-
-OSC addresses follow a URL or directory tree structure, such as /voices/synth1/osc1/modfreq.
-'''
+import struct
 
 # <-- parameters
 
-from java.io import File
-from org.nodel.io import Stream
-
-DEFAULT_IPADDRESS = "127.0.0.1"
+DEFAULT_IPADDRESS = '127.0.0.1'
 DEFAULT_PORT = 9000
+DEFAULT_PATTERN = '/foo/bar'
 
-DEFAULT_PATTERN = "/foo/bar"
+param_ipAddress = Parameter({
+    'title': 'IP address',
+    'schema': {'type': 'string', 'hint': DEFAULT_IPADDRESS},
+    'order': next_seq()
+})
 
-param_ipAddress = Parameter({'title': 'IP address', 'schema': {
-                            'type': 'string', 'hint': DEFAULT_IPADDRESS}, 'order': next_seq()})
-param_port = Parameter({'title': 'Port', 'schema': {
-                       'type': 'integer', 'hint': DEFAULT_PORT}, 'order': next_seq()})
+param_port = Parameter({
+    'title': 'Port',
+    'schema': {'type': 'integer', 'hint': DEFAULT_PORT},
+    'order': next_seq()
+})
 
-param_patterns = Parameter({'title': 'Patterns', 'order': next_seq(), 'schema': {'type': 'array', 'items': {
-    'type': 'object', 'title': 'Pattern', 'properties': {
+param_receivePort = Parameter({
+    'title': 'Receive port',
+    'desc': 'Optional. Bind this local UDP port to listen for replies. Leave '
+            'empty to send only. Outgoing messages also originate from this '
+            'port, so devices that reply to the sender are answered here.',
+    'schema': {'type': 'integer', 'hint': 'empty (send only)'},
+    'order': next_seq()
+})
+
+param_patterns = Parameter({
+    'title': 'Patterns',
+    'desc': 'One action per entry. Leave Argument empty and the operator '
+            'supplies a value when the action is called, for a fader or a '
+            'level. Fill Argument in and the action becomes a plain button '
+            'that always sends that value, for a preset or a cue.',
+    'order': next_seq(),
+    'schema': {'type': 'array', 'items': {
+        'type': 'object', 'title': 'Pattern', 'properties': {
             'label': {'type': 'string', 'title': 'Label', 'hint': 'Foobar', 'order': next_seq()},
-        'address': {'type': 'string', 'title': 'Address', 'hint': '/foo/bar', 'order': next_seq()}
-    }}}})
+            'address': {'type': 'string', 'title': 'Address', 'hint': DEFAULT_PATTERN, 'order': next_seq()},
+            'args': {'type': 'string', 'title': 'Argument', 'hint': 'optional, e.g. 12 or "cue name"', 'order': next_seq()}
+        }}}
+})
 
 # -->
 
-# <-- functions
+# <-- OSC 1.0 codec
 
-# batch local actions sending OSC messages based on parameter patterns
-def create_client_action(pattern):
+def osc_string(value):
+    'Encodes an OSC-string: null terminated, padded to a multiple of 4 bytes.'
+    if isinstance(value, unicode):
+        data = value.encode('utf-8')
+    else:
+        data = str(value)
 
-  def default_handler(arg):
-    
-    # address pattern
-    oscmsg = OSC.OSCMessage()
-    oscmsg.setAddress(pattern['address'])
+    data += '\x00'
+    return data + ('\x00' * ((4 - (len(data) % 4)) % 4))
 
-    # optional argument
-    if arg:
-      if isinstance(arg, int):
-        # last minute have to add this, remove from generic client
-        arg = get_float(arg)
-      else:
-        arg = get_number(arg)
-      oscmsg.append(arg)
 
-    # send
-    console.log('Sending [ %s ] to [ %s ].' % (arg, pattern['address']))
-    udp.send(oscmsg.getBinary())
+def osc_blob(value):
+    'Encodes an OSC-blob: int32 length, then data padded to a multiple of 4.'
+    data = str(value)
+    return struct.pack('>i', len(data)) + data + ('\x00' * ((4 - (len(data) % 4)) % 4))
 
-  create_local_action(
-      name='%s' % pattern['label'],
-      metadata=basic_meta('%s' % pattern['label'], '%s' % pattern['address']),
-      handler=default_handler
-  )
 
-# a custom action for sending arbitrary OSC messages
-def create_custom_action():
+def osc_message(address, args):
+    '''
+    Encodes an OSC message. `args` is a list of (tag, value) pairs as produced
+    by `parse_arguments`. An empty list produces a message with the bare `,`
+    type tag string, which is what a device expects for a no-argument command.
+    '''
+    tags = ','
+    body = ''
 
-  def generic_osc_handler(message):
-    if message != None:
+    for tag, value in args:
+        tags += tag
+        if tag == 'i':
+            body += struct.pack('>i', int(value))
+        elif tag == 'f':
+            body += struct.pack('>f', float(value))
+        elif tag == 's':
+            body += osc_string(value)
+        elif tag == 'b':
+            body += osc_blob(value)
+        # 'T', 'F' and 'N' carry no payload
 
-      # address pattern
-      address = (message['address'] or DEFAULT_PATTERN).strip()
-      oscmsg = OSC.OSCMessage()
-      oscmsg.setAddress(address)
+    return osc_string(address) + osc_string(tags) + body
 
-      # optional argument
-      arg = None
-      if message['arg']:
-        if isinstance(message['arg'], int):
-          arg = get_float(message['arg'])
+
+def read_osc_string(data, offset):
+    'Reads a padded OSC-string, returning (value, next offset).'
+    end = data.find('\x00', offset)
+    if end < 0:
+        raise ValueError('unterminated OSC string')
+
+    value = data[offset:end]
+    return value, offset + (((end - offset) // 4) + 1) * 4
+
+
+def decode_osc_message(data):
+    '''
+    Decodes an OSC message into {'address': ..., 'args': [...]}.
+
+    Note: Nodel hands UDP payloads to scripts as text, so a datagram carrying
+    bytes above 0x7F may not survive intact. Addresses and type tags are ASCII
+    and are always safe; numeric arguments are decoded on a best-effort basis.
+    '''
+    address, offset = read_osc_string(data, 0)
+
+    args = []
+    if offset < len(data):
+        tags, offset = read_osc_string(data, offset)
+
+        for tag in tags.lstrip(','):
+            if tag == 'i':
+                args.append(struct.unpack('>i', data[offset:offset + 4])[0])
+                offset += 4
+            elif tag == 'f':
+                args.append(struct.unpack('>f', data[offset:offset + 4])[0])
+                offset += 4
+            elif tag == 's':
+                value, offset = read_osc_string(data, offset)
+                args.append(value)
+            elif tag == 'T':
+                args.append(True)
+            elif tag == 'F':
+                args.append(False)
+            elif tag == 'N':
+                args.append(None)
+            else:
+                # Unknown or unsupported tag: stop rather than mis-read the rest
+                break
+
+    return {'address': address, 'args': args}
+
+# -->
+
+# <-- argument parsing
+
+def split_arguments(text):
+    '''
+    Splits a comma separated argument list into (value, quoted) pairs.
+
+    Quoting serves two purposes: a string argument may contain a comma, and a
+    numeric looking value may be forced to be sent as a string.
+    '''
+    parts = []
+    current = ''
+    quoted = False
+    quote = None
+
+    for char in text:
+        if quote is not None:
+            if char == quote:
+                quote = None
+            else:
+                current += char
+        elif char in ('"', "'"):
+            quote = char
+            quoted = True
+        elif char == ',':
+            parts.append((current, quoted))
+            current = ''
+            quoted = False
         else:
-          arg = get_number(message['arg'])
-        oscmsg.append(arg)
+            current += char
 
-      # send
-      console.log('Sending [ %s ] to [ %s ].' % (arg, address))
-      udp.send(oscmsg.getBinary())
+    parts.append((current, quoted))
+    return parts
 
-  custom_metadata = {'group': 'Custom', 'title': 'Send a custom message', 'schema': {'type': 'object', 'properties': {
-      'address': {'type': 'string', 'title': 'Address', 'hint': DEFAULT_PATTERN, 'order': next_seq()},
-      'arg': {'type': 'string', 'title': 'Argument', 'hint': '1', 'order': next_seq()}
-  }}, 'order': next_seq()}
-  
-  create_local_action('Custom', handler=generic_osc_handler, metadata=custom_metadata)
+
+def type_argument(value):
+    '''
+    Maps a single value onto an (OSC type tag, value) pair.
+
+    Bare digits become int32 and bare decimals become float32, which is what
+    almost every OSC device expects. Quote a value in the action field to force
+    it to be sent as a string.
+    '''
+    if isinstance(value, bool):
+        return ('T' if value else 'F', None)
+
+    if isinstance(value, int) or isinstance(value, long):
+        return ('i', value)
+
+    if isinstance(value, float):
+        return ('f', value)
+
+    text = value if isinstance(value, basestring) else str(value)
+    stripped = text.strip()
+
+    if len(stripped) == 0:
+        return ('s', '')
+
+    try:
+        return ('i', int(stripped))
+    except ValueError:
+        pass
+
+    try:
+        return ('f', float(stripped))
+    except ValueError:
+        pass
+
+    return ('s', text)
+
+
+def parse_arguments(arg):
+    '''
+    Turns an action argument into a list of (tag, value) pairs.
+
+    Accepts `None` and the empty string (no arguments), a number or boolean, a
+    list, or a comma separated string such as `5, 2.0, "cue name"`.
+    '''
+    if arg is None:
+        return []
+
+    if isinstance(arg, list):
+        return [type_argument(item) for item in arg]
+
+    if not isinstance(arg, basestring):
+        return [type_argument(arg)]
+
+    if len(arg.strip()) == 0:
+        return []
+
+    args = []
+    for value, quoted in split_arguments(arg):
+        if quoted:
+            # Quoted values are sent verbatim as strings, never coerced
+            args.append(('s', value))
+        elif len(value.strip()) > 0:
+            args.append(type_argument(value))
+        # An unquoted empty section (e.g. a trailing comma) sends nothing
+
+    return args
+
+# -->
+
+# <-- events
+
+local_event_Received = LocalEvent({
+    'title': 'Received',
+    'group': 'Monitoring',
+    'order': next_seq(),
+    'desc': 'The most recent inbound OSC message. Only emitted when a receive '
+            'port is configured.',
+    'schema': {'type': 'object', 'properties': {
+        'address': {'type': 'string', 'order': 1},
+        'args': {'type': 'array', 'items': {'type': 'string'}, 'order': 2},
+        'source': {'type': 'string', 'order': 3}
+    }}
+})
 
 # -->
 
 # <-- UDP
 
-udp = UDP(ready=lambda: console.info('UDP ready. %s' % udp.getDest()))
+# Parameter values are only bound by the time main() runs; at module scope the
+# param_* names still hold their descriptors. Everything that depends on them
+# is therefore resolved in start_udp(), called from main().
+udp = None
+_receivePort = 0
+
+# Handlers registered by ingredient_*.py scripts, called as
+# handler(address, args, source) for every decoded inbound message.
+_messageHandlers = []
+
+
+def register_message_handler(handler):
+    'Registers a callback for decoded inbound OSC messages.'
+    if handler not in _messageHandlers:
+        _messageHandlers.append(handler)
+
+
+def udp_received(source, data):
+    try:
+        message = decode_osc_message(data)
+    except:
+        console.warn('Received a datagram from %s that is not a valid OSC message.' % source)
+        return
+
+    local_event_Received.emit({
+        'address': message['address'],
+        'args': [str(value) for value in message['args']],
+        'source': str(source)
+    })
+
+    for handler in list(_messageHandlers):
+        try:
+            handler(message['address'], message['args'], source)
+        except:
+            console.error('An inbound OSC message handler failed.')
+
+
+def udp_ready():
+    if _receivePort > 0:
+        console.info('UDP ready. Sending to %s, listening on %s.' % (udp.getDest(), _receivePort))
+    else:
+        console.info('UDP ready. Sending to %s.' % udp.getDest())
+
+
+def start_udp():
+    'Resolves parameter values and opens the socket. Called from main().'
+    global udp, _receivePort
+
+    dest = '%s:%s' % (param_ipAddress or DEFAULT_IPADDRESS, param_port or DEFAULT_PORT)
+    _receivePort = param_receivePort or 0
+
+    if _receivePort > 0:
+        udp = UDP(source='0.0.0.0:%s' % _receivePort, dest=dest,
+                  ready=udp_ready, received=udp_received)
+    else:
+        udp = UDP(dest=dest, ready=udp_ready)
+
+# -->
+
+# <-- logging
+
+local_event_LogLevel = LocalEvent({
+    'title': 'Log level',
+    'group': 'Debug',
+    'order': 10000 + next_seq(),
+    'desc': 'Use this to ramp up the logging (with indentation). 0 is quiet, '
+            '1 shows messages sent on demand, 2 also shows periodic traffic.',
+    'schema': {'type': 'integer'}
+})
+
+
+def log(level, msg):
+    if (local_event_LogLevel.getArg() or 0) >= level:
+        console.log(('  ' * level) + msg)
+
+
+@local_action({'title': 'Raise log level', 'group': 'Debug', 'order': 10000 + next_seq()})
+def RaiseLogLevel(arg=None):
+    local_event_LogLevel.emit(min((local_event_LogLevel.getArg() or 0) + 1, 2))
+
+
+@local_action({'title': 'Lower log level', 'group': 'Debug', 'order': 10000 + next_seq()})
+def LowerLogLevel(arg=None):
+    local_event_LogLevel.emit(max((local_event_LogLevel.getArg() or 0) - 1, 0))
+
+# -->
+
+# <-- functions
+
+def send_osc(address, arg, level=1):
+    '''
+    Encodes and sends a single OSC message. Shared by every action.
+
+    `level` is the log level the send is reported at, so periodic traffic such
+    as a health check can sit at 2 and stay out of the console by default.
+    '''
+    args = parse_arguments(arg)
+    udp.send(osc_message(address, args))
+
+    if len(args) == 0:
+        log(level, 'Sent [ %s ].' % address)
+    else:
+        log(level, 'Sent [ %s ] to [ %s ].' % (', '.join([str(value) for tag, value in args]), address))
+
+
+def create_client_action(pattern):
+    '''
+    Creates one local action per configured pattern.
+
+    With an argument configured the action ignores whatever it is called with
+    and always sends that value, so the dashboard shows a plain button.
+    '''
+    preset = pattern.get('args')
+    fixed = preset is not None and len(preset.strip()) > 0
+
+    def handler(arg=None):
+        send_osc(pattern['address'], preset if fixed else arg)
+
+    create_local_action(
+        name='%s' % pattern['label'],
+        metadata=basic_meta(pattern['label'], pattern['address'], preset if fixed else None),
+        handler=handler
+    )
+
+
+def create_custom_action():
+    'Creates a single action for sending an arbitrary OSC message.'
+
+    def handler(message):
+        if message is None:
+            return
+
+        address = (message.get('address') or DEFAULT_PATTERN).strip()
+        send_osc(address, message.get('args'))
+
+    metadata = {
+        'group': 'Custom',
+        'title': 'Send a custom message',
+        'order': next_seq(),
+        'schema': {'type': 'object', 'properties': {
+            'address': {'type': 'string', 'title': 'Address', 'hint': DEFAULT_PATTERN, 'order': next_seq()},
+            'args': {'type': 'string', 'title': 'Arguments', 'hint': '5, 2.0, "cue name"', 'order': next_seq()}
+        }}
+    }
+
+    create_local_action('Custom', handler=handler, metadata=metadata)
+
+
+def basic_meta(label, address, preset=None):
+    'Action metadata. A preset argument means a button, otherwise a text field.'
+    if preset is not None:
+        return {
+            'title': '%s' % label,
+            'group': 'Patterns',
+            'order': next_seq(),
+            'desc': 'Sends %s to %s.' % (preset, address)
+        }
+
+    return {
+        'title': '%s' % label,
+        'group': 'Patterns',
+        'order': next_seq(),
+        'desc': 'Sends to %s. Arguments are optional and comma separated; '
+                'quote a value to send it as a string.' % address,
+        'schema': {'type': 'string', 'title': '%s' % address}
+    }
 
 # -->
 
 # <-- main
 
 def main(arg=None):
-  console.log('Nodel script started.')
+    console.log('Nodel script started.')
 
-  udp.setDest((param_ipAddress or DEFAULT_IPADDRESS) +
-              ':' + str(param_port or DEFAULT_PORT))
-  
-  # Create a generic local actions for sending custom OSC messages
-  create_custom_action()
+    start_udp()
+    create_custom_action()
 
-  # Generate any user specified pattern-matching local actions from parameters
-  if not is_empty(param_patterns):
-    for pattern in param_patterns:
-      create_client_action(pattern)
-
-# -->
-
-# <-- utilities
-
-def basic_meta(label, address):
-  return {
-      'title': '%s' % label,
-      'group': 'Patterns',
-      'order': next_seq(),
-      'schema': {
-          'type': 'string',
-          'title': '%s' % address
-      }
-  }
-
-def get_number(s):
-  if is_number(s):
-    return int(s) if s.isdecimal() else float(s)
-  else:
-    return s
-
-def get_float(arg):
-  if arg > 1:
-    arg = float(arg)
-    arg = arg / 100
-  return arg
-
-def is_number(s):
-    try:
-        float(s)
-        return True
-    except ValueError:
-        return False
-    
-# -->
-
-# <-- retrieve and write OSC dependency
-PYOSC_URL = 'https://raw.githubusercontent.com/ptone/pyosc/master/OSC.py'
-
-def retrieve_osc_dependency():
-  resp = get_url(PYOSC_URL, fullResponse=True)
-  if resp.statusCode != 200:
-    raise Exception(
-        "Failed to retrieve OSC dependency, got status code: " + str(resp.statusCode))
-
-  return resp.content
-
-def write_osc_file(content):
-  rootDir = File(_node.getRoot(), '')
-  dstFile = File(rootDir, 'OSC.py')
-
-  try:
-    Stream.writeFully(dstFile, content.encode("utf-8"))
-    console.info('"OSC.py" dependency retrieved, restarting node...')
-    call(lambda: _node.restart(), delay = 2.5) # need a brief pause to allow the file to be written
-  except Exception, e:
-    console.error('Failed to write the OSC.py file: ', e)
-
-@after_main
-def check_for_osc_dependency():
-  global OSC
-  try:
-    import OSC
-  except ImportError:
-    console.info('No OSC dependency found, retrieving...')
-    content = retrieve_osc_dependency()
-    write_osc_file(content)
+    if not is_empty(param_patterns):
+        for pattern in param_patterns:
+            create_client_action(pattern)
 
 # -->


### PR DESCRIPTION
The recipe downloads `OSC.py` from `ptone/pyosc` on first run, writes it into the node directory and restarts the node. That repository was last updated in 2013, and on a host without outbound internet the node restart-loops. Rev 3 encodes and decodes OSC 1.0 in the recipe itself, so there is no dependency and no download.

Replacing the encoder surfaced four bugs in argument handling. `get_float()` divides any argument greater than 1 by 100, so cue `5` goes on the wire as `0.05`. `get_number()` calls `s.isdecimal()`, which does not exist on Jython 2.5 `str`. Only one argument is ever appended, so a device command taking two arguments cannot be expressed. And `if arg:` drops a literal `0`.

Patterns entries gain an optional argument. Left empty the generated action behaves as before, taking a value when it is called. Filled in, the action always sends that value and the dashboard renders it as a plain button, which is what you want for a preset or a cue.

Arguments are now comma separated and typed by their form: `5` is an int32, `1.5` a float32, and a quoted value a string. Quoting also lets an argument contain a comma. An empty field sends a real no-argument message instead of omitting the type tag string.

Sends now report through the standard `LogLevel` convention rather than an unconditional `console.log`, so a node polling on a timer no longer fills its console. `send_osc` takes the level to report at, letting periodic traffic sit at 2 while operator-initiated sends stay at 1. `Raise log level` and `Lower log level` actions are included, since the event alone gives an operator no way to change it from the dashboard.

Rev 3 also adds an optional receive port. When set, the socket binds it, inbound messages are decoded into a `Received` event, and an ingredient can register a handler through `register_message_handler`. Left empty, the recipe stays send-only. Socket setup moved into `start_udp()`, called from `main()`, because parameter values are not bound while the module body is still executing.

> [!WARNING]
> Arguments now go on the wire as written. Any node relying on rev 2's divide-by-100 behaviour must be changed to send the already-scaled value.
